### PR TITLE
Add non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,17 @@
 FROM python:3.4
 
+# Set up non-root user
+ENV NB_USER jovyan
+ENV NB_UID 1000
+ENV NB_GID 1000
+ENV HOME /home/${NB_USER}
+
+RUN adduser --disabled-password \
+    --gecos "Default user" \
+    --uid ${NB_UID} \
+    --gid ${NB_GID} \
+    ${NB_USER}
+    
 # Move over things like requirements.txt we'll use later on..
 COPY . .
 


### PR DESCRIPTION
JupyterHub by default tries to run the containers as non-root users for security reasons.